### PR TITLE
Update the runtime to Qt 6.10 and add SoapySDR support

### DIFF
--- a/io.welle.welle-gui.yml
+++ b/io.welle.welle-gui.yml
@@ -1,6 +1,6 @@
 app-id: io.welle.welle-gui
 runtime: org.kde.Platform
-runtime-version: '6.8'
+runtime-version: '6.10'
 sdk: org.kde.Sdk
 command: welle-io
 finish-args:
@@ -36,7 +36,10 @@ modules:
 
   - name: libairspy
     buildsystem: cmake-ninja
+    build-options:
+      cflags: "-std=gnu17"
     config-opts:
+      - '-DCMAKE_POLICY_VERSION_MINIMUM=3.5'
       - '-Wno-dev'
     sources:
       - type: git
@@ -47,6 +50,7 @@ modules:
     buildsystem: cmake-ninja
     config-opts:
       - '-DCMAKE_BUILD_TYPE=Release'
+      - '-DCMAKE_POLICY_VERSION_MINIMUM=3.5'
       - '-Wno-dev'
     sources:
       - type: git
@@ -56,10 +60,11 @@ modules:
   - name: welle.io
     buildsystem: cmake-ninja
     config-opts:
-      - -DBUILD_WELLE_CLI=OFF
-      - -DAIRSPY=ON
-      - -DRTLSDR=ON
-      - -DSOAPYSDR=ON
+      - '-DBUILD_WELLE_CLI=OFF'
+      - '-DCMAKE_POLICY_VERSION_MINIMUM=3.5'
+      - '-DAIRSPY=ON'
+      - '-DRTLSDR=ON'
+      - '-DSOAPYSDR=ON'
     sources:
       - type: git
         url: https://github.com/AlbrechtL/welle.io.git

--- a/io.welle.welle-gui.yml
+++ b/io.welle.welle-gui.yml
@@ -57,6 +57,16 @@ modules:
         url: 'https://github.com/pothosware/SoapySDR.git'
         tag: soapy-sdr-0.8.1
 
+  - name: SoapyRemote
+    buildsystem: cmake-ninja
+    config-opts:
+      - '-DCMAKE_POLICY_VERSION_MINIMUM=3.5'
+      - '-Wno-dev'
+    sources:
+      - type: git
+        url: https://github.com/pothosware/SoapyRemote.git
+        tag: soapy-remote-0.5.2
+
   - name: welle.io
     buildsystem: cmake-ninja
     config-opts:


### PR DESCRIPTION
Also add SoapyRemote support that is useful for SDRplay and similar devices not directly supported by the Flatpak, and also for various networked SDRs.